### PR TITLE
Force 'en-US' culture while converting from Xml

### DIFF
--- a/Designer.ps1
+++ b/Designer.ps1
@@ -390,7 +390,8 @@ $global:control_track = @{}
             [switch]$IncrementName
         )
 
-        try {
+        # Force 'en-US' culture while converting from Xml
+        [Threading.Thread]::CurrentThread.CurrentCulture = 'en-US'; try {
             $controlType = $Xml.ToString()
             $controlName = "$($Xml.Name)"
 			


### PR DESCRIPTION
See #5. Makes sure splitting on ',' etc works as expected when using Non-English locale.

The XML parsing code is hard-coded to assume default English locale, which makes splitting on ',', ';' etc unpredictable when run under another locale. I guess there are better ways, like maybe refactoring the code to be culture-agnostic, but this is a quick, simple solution. Prepending the try clause with CurrentThread.CurrentCulture forces this part of the code to work with a predictable en-US locale, so the XML is parsed correctly, even when the code is run on a system using another language.

Caveat: I've only tested saving and loading a couple of simple projects, as this was sufficient for my use case, and wanted to share my solution. There COULD potentially be issues with localized data in controls?